### PR TITLE
Ubuntu 24 compatibility

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,4 +1,7 @@
 find_package(PCL 1.7 REQUIRED COMPONENTS common io)
+IF("${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}" VERSION_LESS 1.14)
+    SET(PCL_VERSION_SUFFIX "-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
+ENDIF()
 
 if(ROCK_QT_VERSION_4)
     rock_library(ugv_nav4d_gui
@@ -16,8 +19,8 @@ if(ROCK_QT_VERSION_4)
                        sbpl_spline_primitives-viz
                        base-types
                        trajectory_follower-viz
-                       pcl_common-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
-                       pcl_io-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
+                       pcl_common${PCL_VERSION_SUFFIX}
+                       pcl_io${PCL_VERSION_SUFFIX}
     )
 
     rock_executable(ugv_nav4d_bin
@@ -51,8 +54,8 @@ if(ROCK_QT_VERSION_5)
                        sbpl_spline_primitives-viz-qt5
                        base-types
                        trajectory_follower-viz-qt5
-                       pcl_common-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
-                       pcl_io-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
+                       pcl_common${PCL_VERSION_SUFFIX}
+                       pcl_io${PCL_VERSION_SUFFIX}
     )
 
     rock_executable(ugv_nav4d_bin-qt5


### PR DESCRIPTION
@haider8645  This should be the last fix required for Ubuntu24 compatibility. 
These need to be merged as well:
* https://github.com/haider8645/slam-maps/pull/1
* https://github.com/dfki-ric/traversability_generator3d/pull/1
* https://github.com/pierrewillenbrockdfki/gui-vizkit3d_debug_drawings/pull/2 (@pierrewillenbrockdfki)

I can test a fresh build once all are merged