### PR TITLE
Make sure GUIs and unit tests also build when DebugDrawings are enabled.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,9 @@ set(DEPS_PKGCONFIG_LIST
 
 if (ENABLE_DEBUG_DRAWINGS)
 	list(APPEND DEPS_PKGCONFIG_LIST vizkit3d_debug_drawings-commands)
+	# These are (only) required for building the GUIs:
+	list(APPEND DEPS_PKGCONFIG_QT4 vizkit3d_debug_drawings)
+	list(APPEND DEPS_PKGCONFIG_QT5 vizkit3d_debug_drawings-qt5)
 endif()
 
 rock_library(ugv_nav4d

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ROCK_QT_VERSION_4)
                        trajectory_follower-viz
                        pcl_common${PCL_VERSION_SUFFIX}
                        pcl_io${PCL_VERSION_SUFFIX}
+                       ${DEPS_PKGCONFIG_QT4}
     )
 
     rock_executable(ugv_nav4d_bin
@@ -59,6 +60,7 @@ if(ROCK_QT_VERSION_5)
                        trajectory_follower-viz-qt5
                        pcl_common${PCL_VERSION_SUFFIX}
                        pcl_io${PCL_VERSION_SUFFIX}
+                       ${DEPS_PKGCONFIG_QT5}
     )
 
     rock_executable(ugv_nav4d_bin-qt5

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,23 +1,13 @@
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
-add_executable(test_ugv_nav4d test_ugv_nav4d.cpp)
-add_executable(test_EnvironmentXYZTheta test_EnvironmentXYZTheta.cpp)
 
-
-target_link_libraries(test_ugv_nav4d           PRIVATE ugv_nav4d Boost::filesystem)
-target_link_libraries(test_EnvironmentXYZTheta PRIVATE ugv_nav4d Boost::filesystem)
-
-
-# Install the binaries
-install(TARGETS test_ugv_nav4d EXPORT test_ugv_nav4d-targets
-	ARCHIVE DESTINATION lib
-	LIBRARY DESTINATION lib
-	RUNTIME DESTINATION bin
+rock_executable(test_ugv_nav4d
+    SOURCES test_ugv_nav4d.cpp
+    DEPS_PKGCONFIG ugv_nav4d
 )
 
-install(TARGETS test_EnvironmentXYZTheta EXPORT test_EnvironmentXYZTheta-targets
-	ARCHIVE DESTINATION lib
-	LIBRARY DESTINATION lib
-	RUNTIME DESTINATION bin
+rock_executable(test_EnvironmentXYZTheta
+    SOURCES test_EnvironmentXYZTheta.cpp
+    DEPS Boost::filesystem
+    DEPS_PKGCONFIG ugv_nav4d
 )
-


### PR DESCRIPTION
Also, use `rock_executable` macro for unit tests.

This should replace PR #20. Checks for existence of pkg-config dependencies is implied by the rock-macros.