### PR TITLE
Before installing OS-dependencies, check if they are already installed.

### DIFF
--- a/source_dependencies/install_os_dependencies.bash
+++ b/source_dependencies/install_os_dependencies.bash
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-sudo apt-get update
-sudo apt-get install -y doxygen
-sudo apt-get install -y xdot
-sudo apt-get install -y qttools5-dev qttools5-dev-tools
-sudo apt-get install -y libopenscenegraph-dev libeigen3-dev libcgal-dev libpcl-dev
-sudo apt-get install -y libboost-filesystem-dev libboost-serialization-dev libboost-system-dev 
+DEPS="doxygen xdot qttools5-dev qttools5-dev-tools libopenscenegraph-dev libeigen3-dev libcgal-dev libpcl-dev libboost-filesystem-dev libboost-serialization-dev libboost-system-dev"
+
+if dpkg --verify $DEPS; then
+  echo "All OS dependencies are installed already. To update them run:"
+  echo "# apt-get update && apt-get upgrade"
+else
+  sudo apt-get update
+  sudo apt-get install -y $DEPS
+fi
+


### PR DESCRIPTION
This avoids having to enter sudo mode unnecessarily.