### PR TITLE
remove includes too, if debug drawings are disabled

### DIFF
--- a/src/DebugDrawingDeclarations.cpp
+++ b/src/DebugDrawingDeclarations.cpp
@@ -1,3 +1,5 @@
+#ifdef ENABLE_DEBUG_DRAWINGS
+
 #include <vizkit3d_debug_drawings/DebugDrawing.hpp>
 
 // planner debug channels
@@ -20,3 +22,5 @@ V3DD_DECLARE_DEBUG_DRAWING_CHANNEL("ugv_nav4d_obs_check_fail_start");
 V3DD_DECLARE_DEBUG_DRAWING_CHANNEL("ugv_nav4d_goalBox");
 V3DD_DECLARE_DEBUG_DRAWING_CHANNEL("ugv_nav4d_startBox");
 V3DD_DECLARE_DEBUG_DRAWING_CHANNEL("ugv_nav4d_primitives");
+
+#endif

--- a/src/EnvironmentXYZTheta.cpp
+++ b/src/EnvironmentXYZTheta.cpp
@@ -4,12 +4,15 @@
 #include <base/Pose.hpp>
 #include <base/Spline.hpp>
 #include <fstream>
-#include <vizkit3d_debug_drawings/DebugDrawing.hpp>
-#include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
 #include "PathStatistic.hpp"
 #include "Dijkstra.hpp"
 #include <limits>
 #include <base-logging/Logging.hpp>
+
+#ifdef ENABLE_DEBUG_DRAWINGS
+#include <vizkit3d_debug_drawings/DebugDrawing.hpp>
+#include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
+#endif
 
 using namespace std;
 using namespace sbpl_spline_primitives;

--- a/src/ObstacleMapGenerator3D.cpp
+++ b/src/ObstacleMapGenerator3D.cpp
@@ -1,6 +1,9 @@
 #include "ObstacleMapGenerator3D.hpp"
+
+#ifdef ENABLE_DEBUG_DRAWINGS
 #include <vizkit3d_debug_drawings/DebugDrawing.hpp>
 #include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
+#endif
 
 using namespace maps::grid;
 

--- a/src/PathStatistic.cpp
+++ b/src/PathStatistic.cpp
@@ -1,8 +1,11 @@
 #include "PathStatistic.hpp"
 #include <unordered_set>
 #include <deque>
+
+#ifdef ENABLE_DEBUG_DRAWINGS
 #include <vizkit3d_debug_drawings/DebugDrawing.hpp>
 #include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
+#endif
 
 ugv_nav4d::PathStatistic::Stats::Stats() :
     obstacles(0), 

--- a/src/Planner.cpp
+++ b/src/Planner.cpp
@@ -2,14 +2,17 @@
 #include <sbpl/planners/araplanner.h>
 #include <sbpl/utils/mdpconfig.h>
 #include <maps/grid/MultiLevelGridMap.hpp>
-#include <vizkit3d_debug_drawings/DebugDrawing.hpp>
-#include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
 #include <base/Eigen.hpp>
 #include "PlannerDump.hpp"
 #include <omp.h>
 #include <cmath>
 #include <base-logging/Logging.hpp>
 #include "Logger.hpp"
+
+#ifdef ENABLE_DEBUG_DRAWINGS
+#include <vizkit3d_debug_drawings/DebugDrawing.hpp>
+#include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
+#endif
 
 using namespace maps::grid;
 using trajectory_follower::SubTrajectory;

--- a/src/gui/PlannerGui.cpp
+++ b/src/gui/PlannerGui.cpp
@@ -10,8 +10,6 @@
 #include <thread>
 #include <vizkit3d/Vizkit3DWidget.hpp>
 #include <ugv_nav4d/PreComputedMotions.hpp>
-#include <vizkit3d_debug_drawings/DebugDrawing.hpp>
-#include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <pcl/io/ply_io.h>
@@ -19,6 +17,11 @@
 #include <ugv_nav4d/PlannerDump.hpp>
 #include <pcl/common/transforms.h>
 #include <base-logging/Logging.hpp>
+
+#ifdef ENABLE_DEBUG_DRAWINGS
+#include <vizkit3d_debug_drawings/DebugDrawing.hpp>
+#include <vizkit3d_debug_drawings/DebugDrawingColors.hpp>
+#endif
 
 using namespace ugv_nav4d;
 


### PR DESCRIPTION
Currently usage of `vizkit3d_debug_drawings` functionality is disabled when `ENABLE_DEBUG_DRAWINGS` is off, but the headers are still included. This fails if the include directories are not added, e.g., because the optional dependency is missing. This PR should fix this, and disable debug drawings properly.